### PR TITLE
Keep nil values in arguments

### DIFF
--- a/lib/vcardigan/vcard.rb
+++ b/lib/vcardigan/vcard.rb
@@ -65,8 +65,6 @@ module VCardigan
         @group = nil
       end
 
-      args.reject!(&:nil?)
-
       # Build the property and add it to the vCard
       if args.any?
         property = build_prop(name, *args)

--- a/spec/examples/vcard_spec.rb
+++ b/spec/examples/vcard_spec.rb
@@ -120,7 +120,7 @@ describe VCardigan::VCard do
         let(:values) { [nil, 'joe@strummer.com'] }
 
         it 'should not build properties from nil args' do
-          fields[name.to_s].first.values.should == [values.last]
+          fields[name.to_s].first.values.count.should == values.count
         end
       end
 


### PR DESCRIPTION
Commit #7974d48 introduced a change where nil values are rejected from
arguments. It can lead to invalid properties with arguments in the
incorrect position.

For example, when you add the address in a vCard with something like
```
vcard.adr postoffice, extended, street, city, region, postalcode, country
```
the resulting line must have all these fields to respect the corresponding positions defined in the RFC. But if any one of these properties return nil, it will be removed from the arguments array and the following fields will not be in the correct position.