### PR TITLE
Don't set a field if all of its components are nil 

### DIFF
--- a/lib/vcardigan/vcard.rb
+++ b/lib/vcardigan/vcard.rb
@@ -65,13 +65,9 @@ module VCardigan
         @group = nil
       end
 
-      args.reject!(&:nil?)
-
       # Build the property and add it to the vCard
-      if args.any?
-        property = build_prop(name, *args)
-        add_prop(property)
-      end
+      property = build_prop(name, *args)
+      add_prop(property)
     end
 
     def remove(name)

--- a/lib/vcardigan/vcard.rb
+++ b/lib/vcardigan/vcard.rb
@@ -65,9 +65,10 @@ module VCardigan
         @group = nil
       end
 
-      # Build the property and add it to the vCard
-      property = build_prop(name, *args)
-      add_prop(property)
+      if args.any?
+        property = build_prop(name, *args)
+        add_prop(property)
+      end
     end
 
     def remove(name)

--- a/spec/examples/vcard_spec.rb
+++ b/spec/examples/vcard_spec.rb
@@ -108,6 +108,20 @@ describe VCardigan::VCard do
         groups[group.to_s].first.should be_an_instance_of(VCardigan::Property)
       end
     end
+
+    context 'regardless of group' do
+      before do
+        vcard.add(name, *values)
+      end
+
+      context 'when all of the given values are nil' do
+        let(:values) { [nil, nil] }
+
+        it 'should not add anything to the fields hash' do
+          fields[name.to_s].should be_nil
+        end
+      end
+    end
   end
 
   describe "#remove" do
@@ -277,16 +291,23 @@ describe VCardigan::VCard do
   describe "#valid?" do
     let(:vcard) { VCardigan.create }
 
-    context 'with no FN' do
-      it 'it should return false' do
-        expect( vcard.valid? ).to be_false
+    context 'when full name has not been set' do
+      it 'should return false' do
+        expect(vcard).not_to be_valid
       end
     end
 
-    context 'with FN' do
-      it 'it should return true' do
+    context 'when full name has been set' do
+      it 'should return true' do
         vcard.fullname("My Name")
-        expect( vcard.valid? ).to be_true
+        expect(vcard).to be_valid
+      end
+    end
+
+    context 'when full name has been set to nil' do
+      it 'should return false' do
+        vcard.fullname(nil)
+        expect(vcard).not_to be_valid
       end
     end
   end

--- a/spec/examples/vcard_spec.rb
+++ b/spec/examples/vcard_spec.rb
@@ -108,31 +108,6 @@ describe VCardigan::VCard do
         groups[group.to_s].first.should be_an_instance_of(VCardigan::Property)
       end
     end
-
-    context 'regardless of group' do
-
-      before do
-        vcard.add(name, *values)
-      end
-
-      context 'some args are nil' do
-
-        let(:values) { [nil, 'joe@strummer.com'] }
-
-        it 'should not build properties from nil args' do
-          fields[name.to_s].first.values.should == [values.last]
-        end
-      end
-
-      context 'all args are nil' do
-
-        let(:values) { [nil, nil] }
-
-        it 'should not build properties' do
-          fields[name.to_s].should be_nil
-        end
-      end
-    end
   end
 
   describe "#remove" do


### PR DESCRIPTION
This PR is a re-implementation of the behavior introduced in 7974d48
in a way that does not omit nil components completely (thereby fixing #9).

The original intent of this commit was to make it so that a vCard cannot
be created without a full name. Prior to this commit, the following
would hold true:

``` ruby
vcard = VCardigan.create
vcard.fn(nil)
vcard.valid?  #=> true
```

Now this is no longer the case:

``` ruby
vcard = VCardigan.create
vcard.fn(nil)
vcard.valid?  #=> false
```

(This behavior applies to other fields as well.)

Hat tip: @gdott9.