### PR TITLE
VCard#respond_to? returns true for missing methods

### DIFF
--- a/lib/vcardigan/vcard.rb
+++ b/lib/vcardigan/vcard.rb
@@ -56,6 +56,10 @@ module VCardigan
       end
     end
 
+    def respond_to_missing?(name, include_private = false)
+      true
+    end
+
     def add(name, *args)
       if @group
         # If there's a group, add it to the name

--- a/spec/examples/vcard_spec.rb
+++ b/spec/examples/vcard_spec.rb
@@ -192,6 +192,14 @@ describe VCardigan::VCard do
     end
   end
 
+  describe '#respond_to?' do
+    let(:vcard) { VCardigan.create }
+
+    it 'should always return true, even for missing methods' do
+      expect(vcard).to respond_to(:whatever)
+    end
+  end
+
   describe '#field' do
     let(:vcard) { VCardigan.create }
     let(:fields) { vcard.instance_variable_get(:@fields) }


### PR DESCRIPTION
Since VCard overrides #method_missing to always do something, it stands
to reason that #responds_to_missing? should always return true. This
makes it possible to decorate an instance of VCard using
SimpleDelegator, specifically so that sending missing methods to the
decorator to access or set fields will delegate onwards to the VCard
instance.