### PR TITLE
Fix array values for params

### DIFF
--- a/lib/vcardigan/property.rb
+++ b/lib/vcardigan/property.rb
@@ -67,7 +67,7 @@ module VCardigan
       values = parts.last.split(';')
       params = parts.first.split(';')
       name = params.shift
-      
+
       # Create argument array
       args = [vcard, name]
 
@@ -84,7 +84,7 @@ module VCardigan
       # Instantiate a new class with the argument array
       self.create(*args)
     end
-    
+
     def value(idx = 0)
       @values[idx]
     end
@@ -143,15 +143,19 @@ module VCardigan
     end
 
     def param_value(name, value)
-      case name
-      when 'preferred'
-        value = value.to_s
-        number = value.to_i
-        if number > 0
-          value = number
-        else 
-          value = nil if value.downcase == 'false' or value == '0'
-          value = 1 if value
+      if value.is_a? Array
+        value = value.join(',')
+      else
+        case name
+        when 'preferred'
+          value = value.to_s
+          number = value.to_i
+          if number > 0
+            value = number
+          else
+            value = nil if value.downcase == 'false' or value == '0'
+            value = 1 if value
+          end
         end
       end
       value


### PR DESCRIPTION
Your example shows that `vcard.email 'joe@strummer.com', :type => ['work', 'internet'], :preferred => 1` should turn into `EMAIL;TYPE=work,internet;PREF=1:joe@strummer.com` but in my testing it actually outputs `EMAIL;TYPE=["work", "internet"];PREF=1:joe@strummer.com` which is not valid. This just adds a check for array hash values and joins them with ',' to match the expectation of the examples and output valid vcards (at least for this use-case). I'm not an expert at vcard formats so I do not know if this causes any problems with other use-cases.
